### PR TITLE
Fix the IPN endpoint URL to ipnpb.paypal.com

### DIFF
--- a/ipn.php
+++ b/ipn.php
@@ -107,7 +107,7 @@ foreach ($availability->c as $condition) {
 }
 
 // Open a connection back to PayPal to validate the data.
-$paypaladdr = empty($CFG->usepaypalsandbox) ? 'www.paypal.com' : 'www.sandbox.paypal.com';
+$paypaladdr = empty($CFG->usepaypalsandbox) ? 'ipnpb.paypal.com' : 'ipnpb.sandbox.paypal.com';
 $c = new curl();
 $options = array(
     'returntransfer' => true,


### PR DESCRIPTION
This is the same fix that was done in Moodle core in MDL-61741. The
PayPal's IPN specification says to use these URLs.

https://developer.paypal.com/docs/api-basics/notifications/ipn/IPNImplementation/