### PR TITLE
Use the right class for the message to be sent

### DIFF
--- a/ipn.php
+++ b/ipn.php
@@ -202,7 +202,7 @@ function availability_paypal_message_error_to_admin($subject, $data) {
         $message .= "{$key} => {$value};";
     }
 
-    $eventdata = new stdClass();
+    $eventdata = new \core\message\message();
     $eventdata->component         = 'availability_paypal';
     $eventdata->name              = 'payment_error';
     $eventdata->userfrom          = $admin;


### PR DESCRIPTION
Starting from Moodle 2.9, the stdClass should not be used for the
messages. The support for using it was dropped in Moodle 3.6.

In newer versions, no message was sent to the admin and instead the
following error is thrown:

```
availability_paypal IPN exception handler: Exception - Argument 1 passed
to message_send() must be an instance of core\message\message, instance
of stdClass given, called in /availability/condition/paypal/ipn.php on line 217
```

References:

* https://tracker.moodle.org/browse/MDL-55449
* https://docs.moodle.org/dev/Message_API#How_to_send_a_message
* https://docs.moodle.org/dev/Moodle_2.9_release_notes#For_developers