### PR TITLE
Fix notifications not sent on IPN processing errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,7 @@
+== Release 15 ==
+
+* Notifications on pending payments and payment errors fixed and improved.
+* There is a new capability "Receive payment notifications"
+  (availability/paypal:receivenotifications) that controls who should be notified
+  about payment errors. If unused, the plugin will notify all site admins by default.
+* Overall review and improvements of the IPN handler script.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This works like the [PayPal enrol plugin](https://docs.moodle.org/en/Paypal_enro
 
 For each restriction you add, you can set a business email address, cost, currency, item name and item number.
 
+In case of problems with the payment, all users with the capability "Receive payment notifications" (availability/paypal:receivenotifications) are notified via email and Moodle messaging. If there is no dedicated user with that capability, all site administrators are notified by default.
+
+
 Funding
 -------
 

--- a/db/access.php
+++ b/db/access.php
@@ -1,0 +1,38 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Plugin capabilities are defined here.
+ *
+ * @package     availability_paypal
+ * @category    access
+ * @copyright   2021 David Mudrák <david@moodle.com>
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$capabilities = [
+
+    'availability/paypal:receivenotifications' => [
+        'captype' => 'view',
+        'contextlevel' => CONTEXT_SYSTEM,
+        'archetypes' => [
+            'manager' => CAP_ALLOW,
+        ],
+        'clonepermissionsfrom' => 'moodle/site:config',
+    ],
+];

--- a/db/messages.php
+++ b/db/messages.php
@@ -1,0 +1,47 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Plugin message providers are defined here.
+ *
+ * @package     availability_paypal
+ * @category    message
+ * @copyright   2021 David Mudrák <david@moodle.com>
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$messageproviders = [
+    // Notification for users that their payment is pending.
+    'payment_pending' => [
+        'defaults' => [
+            'airnotifier' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF,
+            'popup' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF,
+            'email' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF,
+        ],
+    ],
+
+    // Notifications about problems with payments.
+    'payment_error' => [
+        'capability' => 'availability/paypal:receivenotifications',
+        'defaults' => [
+            'popup' => MESSAGE_PERMITTED,
+            'airnotifier' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF,
+            'email' => MESSAGE_FORCED + MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF,
+        ],
+    ],
+];

--- a/ipn.php
+++ b/ipn.php
@@ -29,6 +29,8 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+define('NO_MOODLE_COOKIES', 1);
+
 // This file do not require login because paypal service will use to confirm transactions.
 // @codingStandardsIgnoreLine
 require("../../../config.php");

--- a/ipn.php
+++ b/ipn.php
@@ -83,14 +83,18 @@ $data->sectionid   = (int)$custom[2];
 $data->timeupdated = time();
 
 if (!$user = $DB->get_record("user", array("id" => $data->userid))) {
+    $PAGE->set_context(context_system::instance());
     availability_paypal_message_error_to_admin("Not a valid user id", $data);
     die;
 }
 
 if (!$context = context::instance_by_id($data->contextid, IGNORE_MISSING)) {
+    $PAGE->set_context(context_system::instance());
     availability_paypal_message_error_to_admin("Not a valid context id", $data);
     die;
 }
+
+$PAGE->set_context($context);
 
 if ($context instanceof context_module) {
     $availability = $DB->get_field('course_modules', 'availability', ['id' => $context->instanceid], MUST_EXIST);

--- a/ipn.php
+++ b/ipn.php
@@ -33,7 +33,7 @@ define('NO_MOODLE_COOKIES', 1);
 
 // This file do not require login because paypal service will use to confirm transactions.
 // @codingStandardsIgnoreLine
-require("../../../config.php");
+require(__DIR__ . '/../../../config.php');
 
 require_once($CFG->libdir . '/filelib.php');
 
@@ -53,7 +53,7 @@ if (empty($_POST) or !empty($_GET)) {
 $req = 'cmd=_notify-validate';
 
 foreach ($_POST as $key => $value) {
-        $req .= "&$key=".urlencode($value);
+    $req .= "&$key=" . urlencode($value);
 }
 
 $data = new stdclass();
@@ -75,11 +75,14 @@ $data->parent_txn_id        = optional_param('parent_txn_id', '', PARAM_TEXT);
 $data->payment_type         = optional_param('payment_type', '', PARAM_TEXT);
 $data->payment_gross        = optional_param('mc_gross', '', PARAM_TEXT);
 $data->payment_currency     = optional_param('mc_currency', '', PARAM_TEXT);
+
 $custom = optional_param('custom', '', PARAM_TEXT);
 $custom = explode('-', $custom);
-$data->userid      = (int)$custom[0];
-$data->contextid   = (int)$custom[1];
-$data->sectionid   = (int)$custom[2];
+
+$data->userid = (int) ($custom[0] ?? -1);
+$data->contextid = (int) ($custom[1] ?? -1);
+$data->sectionid = (int) ($custom[2] ?? -1);
+
 $data->timeupdated = time();
 
 if (!$user = $DB->get_record("user", array("id" => $data->userid))) {
@@ -106,11 +109,14 @@ $availability = json_decode($availability);
 
 $paypal = null;
 
-foreach ($availability->c as $condition) {
-    if ($condition->type == 'paypal') {
-        // TODO: handle more than one paypal for this context.
-        $paypal = $condition;
-        break;
+if ($availability) {
+    // There can be multiple conditions specified. Find the first of the type "paypal".
+    // TODO: Support more than one paypal condition specified.
+    foreach ($availability->c as $condition) {
+        if ($condition->type == 'paypal') {
+            $paypal = $condition;
+            break;
+        }
     }
 }
 

--- a/ipn.php
+++ b/ipn.php
@@ -43,7 +43,7 @@ set_exception_handler('availability_paypal_ipn_exception_handler');
 
 // Keep out casual intruders.
 if (empty($_POST) or !empty($_GET)) {
-    print_error("Sorry, you can not use the script that way.");
+    die("Sorry, you can not use the script that way.");
 }
 
 // Read all the data from PayPal and get it ready for later;

--- a/lang/en/availability_paypal.php
+++ b/lang/en/availability_paypal.php
@@ -1,5 +1,5 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,15 +12,18 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
  * Language strings.
  *
- * @package availability_paypal
- * @copyright 2015 Daniel Neis Araujo <danielneis@gmail.com>
- * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @package     availability_paypal
+ * @category    string
+ * @copyright   2015 Daniel Neis Araujo <danielneis@gmail.com>
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+
+defined('MOODLE_INTERNAL') || die();
 
 $string['ajaxerror'] = 'Error contacting server';
 $string['businessemail'] = 'Business email';
@@ -35,14 +38,17 @@ $string['error_itemname'] = 'You must provide an item name.';
 $string['error_itemnumber'] = 'You must provide an item number.';
 $string['itemname'] = 'Item name';
 $string['itemname_help'] = 'Name of the item to be shown on PayPal form';
-$string['itemnumber'] = 'Item number';
 $string['itemname_help'] = 'Number of the item to be shown on PayPal form';
+$string['itemnumber'] = 'Item number';
+$string['messageprovider:payment_error'] = 'Payment errors';
+$string['messageprovider:payment_pending'] = 'Pending payments';
 $string['notdescription'] = 'you have not sent a <a href="{$a}">payment with PayPal</a>';
 $string['paymentcompleted'] = 'Your payment was accepted and now you can access the activity or resource. Thank you.';
 $string['paymentinstant'] = 'Use the button below to pay and access the activity or resource.';
 $string['paymentpending'] = 'There is a pending payment registered for you.';
 $string['paymentrequired'] = 'You must make a payment via PayPal to access the activity or resource.';
 $string['paymentwaitreminder'] = 'Please note that if you already made a payment recently, it should be processing. Please wait a few minutes and refresh this page.';
+$string['paypal:receivenotifications'] = 'Receive payment notifications';
 $string['paypalaccepted'] = 'PayPal payments accepted';
 $string['pluginname'] = 'PayPal';
 $string['sendpaymentbutton'] = 'Send payment via PayPal';

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2021040701;
+$plugin->version = 2021072003;
 $plugin->requires = 2018120300;
 $plugin->release = 14;
 $plugin->maturity   = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -26,6 +26,6 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->version = 2021072003;
 $plugin->requires = 2018120300;
-$plugin->release = 14;
+$plugin->release = 15;
 $plugin->maturity   = MATURITY_STABLE;
 $plugin->component = 'availability_paypal';


### PR DESCRIPTION
We had serious issues with the plugin last week at learn.moodle.org. While debugging our problem (which later led to MDL-72180) we also discovered that this plugins is not sending the notifications about transaction failures as it should. What we found instead in the logs was:

> PHP Notice: Attempt to send msg from a provider availability_paypal/payment_error that is inactive or not allowed for the user id=2

It turned out the the plugin did not have the messaging API implemented correctly and it did not declare the messaging providers as per https://docs.moodle.org/dev/Message_API

As I was looking closely at the IPN handler I also noticed couple of other problems - for example this loop https://github.com/danielneis/moodle-availability_paypal/blob/3ac8ba0718a0b2973f070f734733fb2c940a30bd/ipn.php#L99-L107 caused that the plugin would falsely notify the admin if the PayPal condition was not stored as the very first one in the JSON list (it did not because the messaging did not work) - and the message text mentioning context would be totally confusing.

So this is my attempt to fix all spotted issues and most notably - make the messaging actual work.

To test, I was using variants of:

    $ curl http://my.moodle.net/availability/condition/paypal/ipn.php -d "custom=1-2-3"