### PR TITLE
fix Throwable usage issue

### DIFF
--- a/ipn.php
+++ b/ipn.php
@@ -302,7 +302,7 @@ function availability_paypal_message_error($subject, $data) {
             message_send($message);
 
         } catch (Throwable $t) {
-            debugging('availability_paypal IPN: exception while sending message: ' . $t->message);
+            debugging('availability_paypal IPN: exception while sending message: ' . $t->getMessage());
         }
     }
 }


### PR DESCRIPTION
Throwable object doesn't access to message variable and we must use getMessage() function.